### PR TITLE
feat: 테스트페이지 슬라이더 구현

### DIFF
--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -17,3 +17,13 @@ button {
   color: white;
   border: 6px solid white;
 }
+
+.btn_resultPage {
+  width: 200px;
+  height: 100px;
+  line-height: 100px;
+  font-size: 18px;
+  background-color: #1a1f24;
+  color: white;
+  border: 6px solid white;
+}

--- a/src/components/LiveResultCard.css
+++ b/src/components/LiveResultCard.css
@@ -1,0 +1,19 @@
+/* 컨테이너/카드 스타일은 동일 */
+.live-result-card {
+  background: #1a1f24;
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  max-width: 520px;
+  color: #e5e7eb;
+  font-family: system-ui, sans-serif;
+
+  width: 500px;
+  height: 800px;
+}
+
+.live-result-card__title h2 {
+  margin: 0 0 6px;
+  font-size: 24px;
+  font-weight: 700;
+}

--- a/src/components/LiveResultCard.jsx
+++ b/src/components/LiveResultCard.jsx
@@ -1,0 +1,31 @@
+import './LiveResultCard.css';
+
+const mokeData = {
+  f1: [
+    { team: 'Red Bull Racing' },
+    { team: 'Mercedes-AMG' },
+    { team: 'Ferrari' },
+  ],
+  baseball: [
+    { team: '롯데 자이언츠' },
+    { team: '두산 베어스' },
+    { team: 'NC 다이노스' },
+  ],
+};
+
+const LiveResultCard = ({ type }) => {
+  return (
+    <div className="live-result-card">
+      <h2 className="live-result-card__title">실시간 결과</h2>
+      <ol className="live-result-card__list">
+        {mokeData[type].map((item, idx) => (
+          <li key={idx} className="live-result-card__item">
+            <span className="live-result-card__team">{item.team}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default LiveResultCard;

--- a/src/components/WeightSlider.css
+++ b/src/components/WeightSlider.css
@@ -1,0 +1,93 @@
+/* 컨테이너/카드 스타일은 동일 */
+.weight-slider {
+  background: #1a1f24;
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  max-width: 520px;
+  color: #e5e7eb;
+  font-family: system-ui, sans-serif;
+
+  width: 500px;
+  height: 800px;
+}
+
+.weight-slider__header h2 {
+  margin: 0 0 6px;
+  font-size: 24px;
+  font-weight: 700;
+}
+.weight-slider__header p {
+  margin: 0 0 20px;
+  color: #9aa3ad;
+  font-size: 14px;
+}
+
+.weight-slider__list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding-right: 8px;
+}
+
+.weight-slider__item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'label label'
+    'range value';
+  row-gap: 8px;
+  column-gap: 12px;
+  padding: 14px 18px;
+  border-radius: 12px;
+  background: #20262d;
+}
+
+.weight-slider__label {
+  grid-area: label;
+  font-weight: 700;
+  color: #ff6259;
+}
+.weight-slider__value {
+  grid-area: value;
+  align-self: center;
+  justify-self: end;
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: #2a3037;
+  min-width: 36px;
+  text-align: center;
+}
+
+/* ===== 슬라이더: 프리픽스 없이 가능한 최대한 깔끔하게 ===== */
+.weight-slider__range {
+  grid-area: range;
+  width: 100%;
+  /* accent-color: 지원 브라우저에서 thumb/채움색을 한 번에 통일 */
+  accent-color: #ff6259; /* ✅ 크롬/엣지/사파리/파폭 최신 지원 */
+  background: transparent; /* 기본 배경 제거(브라우저가 알아서 렌더) */
+  height: 28px; /* 클릭 영역 넓혀 접근성 개선 */
+  margin: 0;
+  cursor: pointer;
+  outline: none; /* 파란 포커스 링 제거 */
+  /* 살짝 세로 스케일로 ‘두꺼운 트랙’ 느낌 (thumb도 같이 굵어지지만 깔끔) */
+  transform: scaleY(1.15);
+  transform-origin: center;
+}
+
+/* 가장자리 잘림 방지용 여백(thumb이 모서리에 닿는 느낌 완화) */
+.weight-slider__range {
+  padding-right: 10px;
+  box-sizing: border-box;
+}
+
+/* 포커스시 파란색 하이라이트 최소화(표준 속성만 사용) */
+.weight-slider__range:focus-visible {
+  outline: none;
+}
+
+/* Hover 시 살짝 밝게(표준만 사용) */
+.weight-slider__item:hover {
+  filter: brightness(1.02);
+}

--- a/src/components/WeightSlider.jsx
+++ b/src/components/WeightSlider.jsx
@@ -1,0 +1,40 @@
+import './WeightSlider.css';
+import { useState } from 'react';
+
+const WeightSlider = ({ labels }) => {
+  const [values, setValues] = useState(Array(labels.length).fill(0));
+
+  const handleChange = (idx, newValue) => {
+    const updated = [...values];
+    updated[idx] = newValue;
+    setValues(updated);
+  };
+
+  return (
+    <div className="weight-slider">
+      <div className="weight-slider__header">
+        <h2>팀에서 무엇을 중요하게 생각하나요?</h2>
+        <p>슬라이더를 오른쪽으로 움직여 본인의 성향을 표현해 보세요</p>
+      </div>
+      <div className="weight-slider__list">
+        {labels.map((label, idx) => (
+          <div key={idx} className="weight-slider__item">
+            <span className="weight-slider__label">{label}</span>
+            <input
+              className="weight-slider__range"
+              type="range"
+              value={values[idx]}
+              min="0"
+              max="10"
+              step="0.1"
+              onChange={(e) => handleChange(idx, Number(e.target.value))}
+            />
+            <span className="weight-slider__value">{values[idx]}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default WeightSlider;

--- a/src/pages/BaseballTest.css
+++ b/src/pages/BaseballTest.css
@@ -1,0 +1,22 @@
+.baseball-test-page {
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  gap: 40px;
+}
+
+.baseball-test-title {
+  text-align: center;
+}
+
+.test-container {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  justify-content: center;
+}
+
+.button-section {
+  display: flex;
+  justify-content: center;
+}

--- a/src/pages/BaseballTest.jsx
+++ b/src/pages/BaseballTest.jsx
@@ -1,5 +1,44 @@
+import WeightSlider from '../components/WeightSlider';
+import LiveResultCard from '../components/LiveResultCard';
+import Button from '../components/Button';
+import './BaseballTest.css';
+import { useNavigate } from 'react-router-dom';
+
 const BaseballTest = () => {
-  return <div>BaseballTest</div>;
+  const baseballSliderLabels = [
+    '팀 성적',
+    '근본',
+    '프랜차이즈 스타',
+    '성장 가능성(평균 연령대)',
+    '연고지',
+    '팬덤 규모',
+  ];
+
+  const nav = useNavigate();
+  const goResultPage = () => {
+    nav('/result');
+  };
+
+  return (
+    <div className="baseball-test-page">
+      <div className="baseball-test-title">BaseballTest</div>
+      <div className="test-container">
+        <div className="slider-section">
+          <WeightSlider labels={baseballSliderLabels} />
+        </div>
+        <div className="rank-section">
+          <LiveResultCard type={'baseball'} />
+        </div>
+      </div>
+      <div className="button-section">
+        <Button
+          text="결과 보러 가기"
+          type="resultPage"
+          onClick={goResultPage}
+        />
+      </div>
+    </div>
+  );
 };
 
 export default BaseballTest;

--- a/src/pages/F1Test.css
+++ b/src/pages/F1Test.css
@@ -1,0 +1,22 @@
+.f1test-page {
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  gap: 40px;
+}
+
+.f1test-title {
+  text-align: center;
+}
+
+.test-container {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  justify-content: center;
+}
+
+.button-section {
+  display: flex;
+  justify-content: center;
+}

--- a/src/pages/F1Test.jsx
+++ b/src/pages/F1Test.jsx
@@ -1,5 +1,44 @@
+import WeightSlider from '../components/WeightSlider';
+import LiveResultCard from '../components/LiveResultCard';
+import Button from '../components/Button';
+import './F1Test.css';
+import { useNavigate } from 'react-router-dom';
+
 const F1Test = () => {
-  return <div>F1Test</div>;
+  const f1SliderLabels = [
+    '팀 성적',
+    '선수 경력(성적)',
+    '근본',
+    '프랜차이즈 or 유스',
+    '언더독',
+    '팬덤 규모',
+  ];
+
+  const nav = useNavigate();
+  const goResultPage = () => {
+    nav('/result');
+  };
+
+  return (
+    <div className="f1test-page">
+      <div className="f1test-title">F1Test</div>
+      <div className="test-container">
+        <div className="slider-section">
+          <WeightSlider labels={f1SliderLabels} />
+        </div>
+        <div className="rank-section">
+          <LiveResultCard type={'f1'} />
+        </div>
+      </div>
+      <div className="button-section">
+        <Button
+          text="결과 보러 가기"
+          type="resultPage"
+          onClick={goResultPage}
+        />
+      </div>
+    </div>
+  );
 };
 
 export default F1Test;


### PR DESCRIPTION
## 1) 작업한 이슈번호
#6 

## 2) 변경 요약 (What & Why)

- **무엇을** 변경했는지: 테스트페이지 슬라이더 UI 구현
- **왜** 변경했는지(문제/목표): 슬라이더 UI를 재사용하기 위해 컴포넌트로 구현

## 3) 스크린샷/동영상 (UI 변경 시)
<img width="1393" height="1263" alt="image" src="https://github.com/user-attachments/assets/282abc29-a8a9-4cff-9ab8-1dcc5d669c36" />


> 전/후 비교, 반응형(모바일/데스크톱) 캡쳐

- Before:
- After:

## 4) 상세 변경사항 (전부 다)

- 라우팅/페이지: '결과 보러 가기' 버튼을 클릭시 useNavigate 훅을 사용하여 결과 페이지로 넘어가게끔 라우팅 설정
- 컴포넌트: F1Test, BaseballTest 컴포넌트에서 슬라이더 컨테이너와 결과 카드 컨테이너 호출, 이때 props로 type을 넘겨 해당 타입에 맞는 종목의 API와 연결할 예정.
- 상태관리:
- API 호출:
- 스타일:
- 기타:

## 5) 참고사항
