### PR TITLE
feat: homepage 디자인 수정 및 HoverTeamName 추가

### DIFF
--- a/src/components/home/HoverTeamName.css
+++ b/src/components/home/HoverTeamName.css
@@ -1,0 +1,47 @@
+@keyframes floatY {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-15px);
+  }
+}
+
+.float-box {
+  position: absolute;
+  color: #fff;
+  padding: 0.5rem 1.2rem;
+  border-radius: 2rem;
+  font-weight: 600;
+  box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  font-size: 0.9rem;
+  cursor: pointer;
+
+  /* 딜레이를 변수로 받음: --delay가 없으면 0s */
+  animation: floatY 3s ease-in-out var(--delay, 0s) infinite;
+}
+
+/* 박스별 서로 다른 타이밍 */
+.float-delay-1 {
+  --delay: 0s;
+}
+.float-delay-2 {
+  --delay: 0.4s;
+}
+.float-delay-3 {
+  --delay: 0.8s;
+}
+.float-delay-4 {
+  --delay: 1.2s;
+}
+.float-delay-5 {
+  --delay: 1.6s;
+}
+.float-delay-6 {
+  --delay: 2s;
+}

--- a/src/components/home/HoverTeamName.jsx
+++ b/src/components/home/HoverTeamName.jsx
@@ -1,5 +1,14 @@
-const HoverTeamName = () => {
-  return <div>HoverTeamName</div>;
+import './HoverTeamName.css';
+
+const HoverTeamName = ({ name, color, xy, delayClass }) => {
+  return (
+    <div
+      className={`float-box ${delayClass ?? ''}`}
+      style={{ left: xy.x, top: xy.y, backgroundColor: color }}
+    >
+      {name}
+    </div>
+  );
 };
 
 export default HoverTeamName;

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -73,7 +73,7 @@
 .first-text {
   display: flex;
   flex-direction: column;
-  margin-left: 20px;
+  align-items: center;
 }
 .main-title {
   font-size: 2.25rem;
@@ -95,6 +95,8 @@
   gap: 1rem;
   margin-right: 20px;
   margin-left: 20px;
+  align-items: center;
+  justify-content: center;
 }
 @media (min-width: 740px) {
   .button-container {
@@ -173,6 +175,8 @@
   backdrop-filter: blur(4px);
   border: 1px solid rgba(75, 85, 99, 0.3);
   gap: 20px;
+
+  position: relative;
 }
 
 .circle-box {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import './Home.css';
 import { useNavigate } from 'react-router-dom';
 import Button from '../components/Button';
 import DescriptionBox from '../components/DescriptionBox';
+import HoverTeamName from '../components/home/HoverTeamName';
 
 import { Trophy, Zap, Users, Target, Heart, Star } from 'lucide-react';
 
@@ -30,6 +31,44 @@ const DB_Description = [
     key: 5,
     title: '승리의 기쁨',
     description: '함께하는 환호',
+  },
+];
+const TeamNames = [
+  {
+    name: 'Ferrari',
+    color: '#E02424',
+    xy: { x: 300, y: 10 },
+    delayClass: 'float-delay-1',
+  },
+  {
+    name: 'Mclaren',
+    color: '#F97316',
+    xy: { x: -160, y: 155 },
+    delayClass: 'float-delay-2',
+  },
+  {
+    name: 'AMG',
+    color: '#10B981',
+    xy: { x: 330, y: 260 },
+    delayClass: 'float-delay-3',
+  },
+  {
+    name: '롯데 자이언츠',
+    color: '#1E3A8A',
+    xy: { x: -120, y: 30 },
+    delayClass: 'float-delay-4',
+  },
+  {
+    name: 'LG 트윈스',
+    color: '#BE185D',
+    xy: { x: 370, y: 120 },
+    delayClass: 'float-delay-5',
+  },
+  {
+    name: '키움 히어로즈',
+    color: '#581C1C',
+    xy: { x: -80, y: 300 },
+    delayClass: 'float-delay-6',
   },
 ];
 
@@ -69,16 +108,16 @@ const Home = () => {
             <div className="first-text">
               <h1 className="main-title">
                 당신에게 딱 맞는
-                <br />
-                <span style={{ color: '#fbbf24' }}>스포츠 팀</span>을
-                <br />
+                <span style={{ color: '#fbbf24' }}> 스포츠 팀</span>을
                 찾아보세요!
               </h1>
-              <p className="description">
+              <div className="description">
                 F1과 KBO의 다양한 팀들 중에서 당신의 성향과 취향에 가장 잘 맞는
-                팀을 추천해드립니다. <br />
+                팀을 추천해드립니다.
+              </div>
+              <div className="description">
                 간단한 테스트로 평생 응원할 팀을 만나보세요.
-              </p>
+              </div>
             </div>
 
             {/* F1, KBO Buttons */}
@@ -115,6 +154,14 @@ const Home = () => {
               >
                 나만의 팀을 찾아보세요!
               </div>
+              {TeamNames.map((b) => (
+                <HoverTeamName
+                  name={b.name}
+                  color={b.color}
+                  xy={b.xy}
+                  delayClass={b.delayClass}
+                />
+              ))}
             </div>
           </div>
 


### PR DESCRIPTION
## 1) 작업한 이슈번호
#17 

## 2) 변경 요약 (What & Why)

- **무엇을** 변경했는지: 홈페이지 디자인 수정 및 둥둥 떠다니는 팀 이름 박스들 추가
- **왜** 변경했는지(문제/목표): figma 디자인 수정으로 인해

## 3) 스크린샷/동영상 (UI 변경 시)

> 전/후 비교, 반응형(모바일/데스크톱) 캡쳐

- Before:
- After: 
<img width="1032" height="385" alt="image" src="https://github.com/user-attachments/assets/efe19867-0fc2-4476-b190-7deec8b12aa6" />


## 4) 상세 변경사항 (전부 다)

- 라우팅/페이지:
- 컴포넌트: HoverTeamName.jsx, Home.jsx
- 상태관리:
- API 호출:
- 스타일: HoverTeamName.css, Home.css
- 기타:

## 5) 참고사항
